### PR TITLE
fix query_builder to encode timestamps correctly

### DIFF
--- a/lib/query_builder/cql/operators/cql_literal.rb
+++ b/lib/query_builder/cql/operators/cql_literal.rb
@@ -20,6 +20,7 @@ module QueryBuilder::CQL::Operators
       return "NaN"                    if nan?(value)
       return "Infinity"               if infinity?(value)
       return value.to_s               if unchanged?(value)
+      return cql_literal_time(value)  if time?(value)
       return cql_literal_array(value) if array?(value)
       return cql_literal_hash(value)  if hash?(value)
       return cql_literal_set(value)   if set?(value)
@@ -42,6 +43,11 @@ module QueryBuilder::CQL::Operators
 
     def cql_literal_set(value)
       "{ #{value.to_a.map{ |v| "\'{v}\'" }.join(', ')} }"
+    end
+
+    def cql_literal_time(value)
+      str = value.strftime("%Y-%m-%dT%H:%M:%S.%L%z")
+      "'#{str}'"
     end
 
     def quote(value)
@@ -86,6 +92,10 @@ module QueryBuilder::CQL::Operators
 
     def set?(value)
       value.is_a? Set
+    end
+
+    def time?(value)
+      value.is_a? Time
     end
 
   end

--- a/spec/integration/insert_spec.rb
+++ b/spec/integration/insert_spec.rb
@@ -19,5 +19,4 @@ describe "INSERT" do
 
     let(:cql) { "INSERT INTO wildlife.species (names, sizes) VALUES (['tiger', 'pantera tigra'], {'length': 3}) USING TIMESTAMP 100 AND TTL 500 IF NOT EXISTS;" }
   end
-
 end # describe INSERT

--- a/spec/unit/cql/operators/cql_literal_spec.rb
+++ b/spec/unit/cql/operators/cql_literal_spec.rb
@@ -80,4 +80,9 @@ describe QueryBuilder::CQL::Operators, ".cql_literal" do
     let(:output) { "['foo', 'bar', {'baz': 0x03}]" }
   end
 
+  it_behaves_like :transforming_immutable_data do
+    let(:input) { Time.at(1631841161.2, in: "-07:00") }
+    let(:output) { "'2021-09-16T18:12:41.200-0700'" }
+  end
+
 end # describe QueryBuilder::CQL::Operators.cql_literal


### PR DESCRIPTION
In Cassandra 4, the parser for time values (for TIMESTAMP columns) is stricter and no longer allows a space between the seconds part and the zone offset.

Without this change, if attempting to put values into a TIMESTAMP column from a ruby Time object, you get errors like the following:

```
Cassandra::Errors::InvalidError: Unable to parse a date/time from '2021-09-17 01:27:44 +0000'
```

I believe this change is an unintended consequence of CASSANDRA-15976